### PR TITLE
Accessibility fixes djprshiny

### DIFF
--- a/R/djpr_plot_box.R
+++ b/R/djpr_plot_box.R
@@ -37,7 +37,7 @@ djpr_plot_box <- function(
         id = NS(id, "date_slider_col"),
         sliderInput(
           NS(id, "dates"),
-          label = "Select Dates",
+          label = "",
           min = as.Date("1978-01-01"),
           max = Sys.Date(),
           value = c(

--- a/R/djpr_plot_box.R
+++ b/R/djpr_plot_box.R
@@ -56,7 +56,7 @@ djpr_plot_box <- function(
         id = NS(id, "check_box_col"),
         shinyWidgets::awesomeCheckboxGroup(
           NS(id, "checkboxes"),
-          label = "",
+          label = "Select Groups",
           choices = NULL,
           selected = NULL,
           inline = TRUE

--- a/R/djpr_plot_box.R
+++ b/R/djpr_plot_box.R
@@ -37,7 +37,7 @@ djpr_plot_box <- function(
         id = NS(id, "date_slider_col"),
         sliderInput(
           NS(id, "dates"),
-          label = "",
+          label = "Select Dates",
           min = as.Date("1978-01-01"),
           max = Sys.Date(),
           value = c(

--- a/R/djpr_plot_box.R
+++ b/R/djpr_plot_box.R
@@ -56,7 +56,7 @@ djpr_plot_box <- function(
         id = NS(id, "check_box_col"),
         shinyWidgets::awesomeCheckboxGroup(
           NS(id, "checkboxes"),
-          label = "Select Groups",
+          label = "",
           choices = NULL,
           selected = NULL,
           inline = TRUE

--- a/R/djpr_shiny_plot.R
+++ b/R/djpr_shiny_plot.R
@@ -97,7 +97,7 @@ djpr_plot_ui <- function(id,
         6,
         id = NS(id, "date_slider_col"),
         sliderInput(NS(id, "dates"),
-          label = "Select Dates",
+          label = "",
           min = as.Date("1978-01-01"),
           max = Sys.Date(),
           value = c(

--- a/R/djpr_shiny_plot.R
+++ b/R/djpr_shiny_plot.R
@@ -97,7 +97,7 @@ djpr_plot_ui <- function(id,
         6,
         id = NS(id, "date_slider_col"),
         sliderInput(NS(id, "dates"),
-          label = "",
+          label = "Select Dates",
           min = as.Date("1978-01-01"),
           max = Sys.Date(),
           value = c(
@@ -256,7 +256,8 @@ djpr_plot_server <- function(id,
           ),
           min = dates$min,
           max = dates$max,
-          timeFormat = "%b %Y"
+          timeFormat = "%b %Y",
+          label = "Select Dates"
         )
 
       } else {

--- a/R/djpr_shiny_plot.R
+++ b/R/djpr_shiny_plot.R
@@ -114,7 +114,7 @@ djpr_plot_ui <- function(id,
         id = NS(id, "check_box_col"),
         shinyWidgets::awesomeCheckboxGroup(
           NS(id, "checkboxes"),
-          label = "Select Groups",
+          label = "",
           choices = NULL,
           selected = NULL,
           inline = TRUE

--- a/R/djpr_shiny_plot.R
+++ b/R/djpr_shiny_plot.R
@@ -114,7 +114,7 @@ djpr_plot_ui <- function(id,
         id = NS(id, "check_box_col"),
         shinyWidgets::awesomeCheckboxGroup(
           NS(id, "checkboxes"),
-          label = "",
+          label = "Select Groups",
           choices = NULL,
           selected = NULL,
           inline = TRUE
@@ -269,7 +269,7 @@ djpr_plot_server <- function(id,
         shinyWidgets::updateAwesomeCheckboxGroup(
           session = session,
           "checkboxes",
-          label = "",
+          label = "Select Groups",
           choices = check_box_options,
           selected = check_box_selected,
           inline = TRUE

--- a/man/djpr_page.Rd
+++ b/man/djpr_page.Rd
@@ -9,7 +9,8 @@ djpr_page(
   ...,
   col_widths = c(2, 8, 2),
   logo = file.path("djprshiny", "spp_data_logo.png"),
-  logo_style = "float:right;width:83px;height:20px;padding-top:0px;"
+  logo_style = "float:right;width:83px;height:20px;padding-top:0px;",
+  lang = "en"
 )
 }
 \arguments{


### PR DESCRIPTION
This fixes issue #103 of djprtradedash. 

Added labels to date sliders ("Select Dates") and check boxes ("Select Groups"). It's working for both dash boards.   
![image](https://user-images.githubusercontent.com/72529836/165221621-7ad8fa4e-68b3-4116-bdd8-e0d8e12dd701.png)

CMD check passed with one warning: Undocumented arguments in documentation object 'djpr_page'
     'lang'
   
   Functions with \usage entries need to have the appropriate \alias
   entries, and all their arguments documented.
   The \usage entries must correspond to syntactically valid R code.
   See chapter 'Writing R documentation files' in the 'Writing R
   Extensions' manual.

No idea what that is as I didn't touch djpr_page.R or the lang object anywhere. Might need help checking this is okay, please.